### PR TITLE
THREAT-506: Support for modifying user-agent when using gcloud CLI

### DIFF
--- a/cmd/grimoire/shell.go
+++ b/cmd/grimoire/shell.go
@@ -249,6 +249,11 @@ func (m *ShellCommand) Do() error {
 		EndTime:      endTime,
 	}
 
+	// Clean up gcloud requirements before processing logs
+	if err := m.cleanupGCloudRequirements(); err != nil {
+		log.Debugf("Failed to cleanup gcloud requirements: %v", err)
+	}
+
 	// Process logs using the shared function
 	return FindLogsForDetonation(context.Background(), detonationInfo, "shell", "", logs.UserAgentMatchTypePartial, nil)
 }


### PR DESCRIPTION
Adds support for using the gcloud CLI tool with a modified user-agent.

This is accomplished by replacing the `config.json` file at the beginning of each new shell with a modified version. I also added the ability for us to append specific commands to be executed at the beginning of a new shell session, which (among other things) allows us to modify the prompt string in a robust way.