### PR TITLE
Add Panther Labs integration documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This fork enhances Grimoire with **end-to-end integration testing for detection 
 
 > 📺 **Learn more**: Watch the "Incorporating End to End Integration Testing into your Detection Engineering Workflow" talk given at [Open Cloud Security Conference](https://youtu.be/4Ijyc2JW-3w) (short version) or BSides Boulder (full version - link TBD)
 
-### Panther Integration Features
+## Panther integration features
 
 **New Log Source**: Query Panther's data lake via GraphQL API instead of AWS CloudTrail
 - Retrieve both raw events and security alerts in one operation

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Query Panther's data lake via GraphQL API instead of AWS CloudTrail:
 - Access extended retention through Panther's data lake
 - Leverage existing Panther infrastructure
 
-**Configuration**:
+### Configuration
 - `--log-source panther` - Use Panther backend
 - `--panther-api-host` - Your Panther GraphQL endpoint  
 - `--panther-api-token` - API authentication token

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Query Panther's data lake via GraphQL API instead of AWS CloudTrail:
 - `--panther-api-token` - API authentication token
 - `--panther-table` - Table to query (default: "aws_cloudtrail")
 
-### Usage with Panther
+## Configuration setup
 
 ```bash
 # Direct configuration

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This fork enhances Grimoire with **end-to-end integration testing for detection 
 ## Key benefits
 
 - **Real attack simulation**: Uses the [Panther Stratus Red Team fork](https://github.com/panther-labs/stratus-red-team) to generate genuine log patterns, not synthetic test data
-- **Complete Pipeline Testing**: Validates detection logic AND alerting infrastructure from log ingestion to alert delivery
+- **Complete pipeline testing**: Validates detection logic _and_ alerting infrastructure, from log ingestion to alert delivery
 - **Alert Correlation**: Correlates CloudTrail events with Panther security alerts to verify detection coverage
 - **Technique Validation**: Confirms whether attack techniques trigger expected Panther detections
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@
   <img src="./logo.png" alt="logo" width="300" />
 </p>
 
-Grimoire is a "REPL for detection engineering" that allows you to generate datasets of cloud audit logs for common attack techniques. It currently supports AWS.
+# Panther-enhanced fork of Grimoire
+
+[Grimoire](https://github.com/dataDog/grimoire) is an interactive shell ("REPL") for detection engineering that allows you to generate datasets of cloud audit logs for common attack techniques. It currently supports AWS.
+
+This repository is a Panther-enhanced fork of Grimoire that adds **end-to-end integration testing for detection engineering**. Instead of using fabricated test cases that may not match real-world log patterns, you can use this fork to generate authentic attack data, allowing for better adversary simulation and detection pipeline validation.
+
+<p align="center">
+  <img src="./logo.png" alt="logo" width="300" />
+</p>
 
 ## Panther Labs Integration
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This fork enhances Grimoire with **end-to-end integration testing for detection 
 
 > 📺 **Learn More**: Watch the talk "Incorporating End to End Integration Testing into your Detection Engineering Workflow" at [Open Cloud Security Conference](https://youtu.be/4Ijyc2JW-3w) (short version) or BSides Boulder (full version - link TBD)
 
-### Key Benefits
+## Key benefits
 
 - **Real Attack Simulation**: Uses [Stratus Red Team](https://github.com/panther-labs/stratus-red-team) (Panther fork) to generate genuine log patterns, not synthetic test data
 - **Complete Pipeline Testing**: Validates detection logic AND alerting infrastructure from log ingestion to alert delivery

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This fork enhances Grimoire with **end-to-end integration testing for detection 
 
 ## Key benefits
 
-- **Real Attack Simulation**: Uses [Stratus Red Team](https://github.com/panther-labs/stratus-red-team) (Panther fork) to generate genuine log patterns, not synthetic test data
+- **Real attack simulation**: Uses the [Panther Stratus Red Team fork](https://github.com/panther-labs/stratus-red-team) to generate genuine log patterns, not synthetic test data
 - **Complete Pipeline Testing**: Validates detection logic AND alerting infrastructure from log ingestion to alert delivery
 - **Alert Correlation**: Correlates CloudTrail events with Panther security alerts to verify detection coverage
 - **Technique Validation**: Confirms whether attack techniques trigger expected Panther detections

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This fork enhances Grimoire with **end-to-end integration testing for detection 
 
 ## Panther integration features
 
-**New Log Source**: Query Panther's data lake via GraphQL API instead of AWS CloudTrail
+### New log source
+Query Panther's data lake via GraphQL API instead of AWS CloudTrail:
 - Retrieve both raw events and security alerts in one operation
 - Access extended retention through Panther's data lake
 - Leverage existing Panther infrastructure

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ This fork enhances Grimoire with **end-to-end integration testing for detection 
 - **Real attack simulation**: Uses the [Panther Stratus Red Team fork](https://github.com/panther-labs/stratus-red-team) to generate genuine log patterns, not synthetic test data
 - **Complete pipeline testing**: Validates detection logic _and_ alerting infrastructure, from log ingestion to alert delivery
 - **Alert correlation**: Correlates CloudTrail events with Panther security alerts to verify detection coverage
-- **Technique Validation**: Confirms whether attack techniques trigger expected Panther detections
+- **Technique validation**: Confirms whether attack techniques trigger expected Panther detections
+
+> 📺 **Learn more**: Watch the "Incorporating End to End Integration Testing into your Detection Engineering Workflow" talk given at [Open Cloud Security Conference](https://youtu.be/4Ijyc2JW-3w) (short version) or BSides Boulder (full version - link TBD)
 
 ### Panther Integration Features
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# Grimoire
-
-<p align="center">
-  <img src="./logo.png" alt="logo" width="300" />
-</p>
-
 # Panther-enhanced fork of Grimoire
 
 [Grimoire](https://github.com/dataDog/grimoire) is an interactive shell ("REPL") for detection engineering that allows you to generate datasets of cloud audit logs for common attack techniques. It currently supports AWS.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@ This repository is a Panther-enhanced fork of Grimoire that adds **end-to-end in
   <img src="./logo.png" alt="logo" width="300" />
 </p>
 
-## Panther Labs Integration
-
-This fork enhances Grimoire with **end-to-end integration testing for detection engineering**. Instead of relying on crafted test cases that may not match real-world log patterns, Grimoire generates authentic attack data and validates your entire detection pipeline.
-
-> 📺 **Learn More**: Watch the talk "Incorporating End to End Integration Testing into your Detection Engineering Workflow" at [Open Cloud Security Conference](https://youtu.be/4Ijyc2JW-3w) (short version) or BSides Boulder (full version - link TBD)
 
 ## Key benefits
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,48 @@
 
 Grimoire is a "REPL for detection engineering" that allows you to generate datasets of cloud audit logs for common attack techniques. It currently supports AWS.
 
+## Panther Labs Integration
+
+This fork enhances Grimoire with **end-to-end integration testing for detection engineering**. Instead of relying on crafted test cases that may not match real-world log patterns, Grimoire generates authentic attack data and validates your entire detection pipeline.
+
+> 📺 **Learn More**: Watch the talk "Incorporating End to End Integration Testing into your Detection Engineering Workflow" at [Open Cloud Security Conference](https://youtu.be/4Ijyc2JW-3w) (short version) or BSides Boulder (full version - link TBD)
+
+### Key Benefits
+
+- **Real Attack Simulation**: Uses [Stratus Red Team](https://github.com/panther-labs/stratus-red-team) (Panther fork) to generate genuine log patterns, not synthetic test data
+- **Complete Pipeline Testing**: Validates detection logic AND alerting infrastructure from log ingestion to alert delivery
+- **Alert Correlation**: Correlates CloudTrail events with Panther security alerts to verify detection coverage
+- **Technique Validation**: Confirms whether attack techniques trigger expected Panther detections
+
+### Panther Integration Features
+
+**New Log Source**: Query Panther's data lake via GraphQL API instead of AWS CloudTrail
+- Retrieve both raw events and security alerts in one operation
+- Access extended retention through Panther's data lake
+- Leverage existing Panther infrastructure
+
+**Configuration**:
+- `--log-source panther` - Use Panther backend
+- `--panther-api-host` - Your Panther GraphQL endpoint  
+- `--panther-api-token` - API authentication token
+- `--panther-table` - Table to query (default: "aws_cloudtrail")
+
+### Usage with Panther
+
+```bash
+# Direct configuration
+grimoire stratus-red-team \
+  --attack-technique aws.credential-access.ssm-retrieve-securestring-parameters \
+  --log-source panther \
+  --panther-api-host https://api.your-panther-instance.com/public-api \
+  --panther-api-token your-api-token
+
+# Using environment file
+cp .env.example .env
+# Edit .env with your credentials
+grimoire stratus-red-team --attack-technique aws.persistence.iam-create-admin-user
+```
+
 <p align="center">
   <a href="https://github.com/DataDog/grimoire/raw/main/stratus-red-team.png">
     <img src="./stratus-red-team.png" alt="Terminal screenshot" />
@@ -24,11 +66,12 @@ Grimoire is a "REPL for detection engineering" that allows you to generate datas
 First, Grimoire detonates an attack. It injects a unique user agent containing a UUID. Then, it polls CloudTrail to retrieve the audit logs caused by the detonation, and streams the resulting logs to an output file or to your terminal.
 
 Supported detonators:
-- [Stratus Red Team](https://github.com/DataDog/stratus-red-team)
+- [Stratus Red Team](https://github.com/panther-labs/stratus-red-team) (Panther Labs fork with custom techniques)
 - AWS CLI interactive shell
 
-Supported logs backend:
+Supported logs backends:
 - AWS CloudTrail (through the `LookupEvents` API)
+- Panther SIEM (through GraphQL API with alert correlation)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This fork enhances Grimoire with **end-to-end integration testing for detection 
 
 - **Real attack simulation**: Uses the [Panther Stratus Red Team fork](https://github.com/panther-labs/stratus-red-team) to generate genuine log patterns, not synthetic test data
 - **Complete pipeline testing**: Validates detection logic _and_ alerting infrastructure, from log ingestion to alert delivery
-- **Alert Correlation**: Correlates CloudTrail events with Panther security alerts to verify detection coverage
+- **Alert correlation**: Correlates CloudTrail events with Panther security alerts to verify detection coverage
 - **Technique Validation**: Confirms whether attack techniques trigger expected Panther detections
 
 ### Panther Integration Features


### PR DESCRIPTION

   - Document end-to-end integration testing approach for detection engineering             
   - Add Panther SIEM backend configuration and usage examples                              
   - Reference talks and Panther's Stratus Red Team fork                                   
   - Update supported backends and detonators sections